### PR TITLE
Fix Bower and Ender URLs

### DIFF
--- a/_posts/30-10-01-Package-Managers-and-Public-CDNS.md
+++ b/_posts/30-10-01-Package-Managers-and-Public-CDNS.md
@@ -6,9 +6,9 @@ isChild: true
 ## Package Managers &amp; Public CDN's
 
 * [NPM](https://npmjs.org/) - Node Packaged Modules
-* [BOWER](http://twitter.github.com/bower/) - A package manager for the web
+* [BOWER](http://bower.io/) - A package manager for the web
 * [Jam](http://jamjs.org/) - The JavaScript package manager
-* [Ender](http://ender.no.de/) - The no-library library
+* [Ender](http://ender.jit.su/) - The no-library library
 * [CDN JS](http://cdnjs.com/) - the missing cdn
 * [YUI Gallery](http://yuilibrary.com/gallery/) - YUI Gallery allows all YUI developers to extend the YUI library rapidly, adding modules that are accessible from any YUI 3 use() statement.
 * [Google Hosted Libraries](https://developers.google.com/speed/libraries/) - The Google Hosted Libraries is a content distribution network for the most popular, open-source JavaScript libraries.


### PR DESCRIPTION
Both package managers moved to a new domain. This patch updates the links.
