### PR TITLE
Fix horizontal scrolling due to Google +1 button in Firefox.

### DIFF
--- a/styles/site/site-content.less
+++ b/styles/site/site-content.less
@@ -18,3 +18,6 @@
     font-size: 12px;
     text-decoration: none !important;
 }
+iframe[id^="oauth2relay"]{
+  position: fixed !important;
+}


### PR DESCRIPTION
There's subtle but annoying horizontal scrolling in Firefox. It's due to the implementation of the Google 1+ button. This fixes it.

http://stackoverflow.com/questions/18437265/google-1-button-adds-scroll-bar-to-my-site
