### PR TITLE
Added Windows Azure as a Node.js PaaS provider.

### DIFF
--- a/_posts/30-09-01-PaaS-Providers.md
+++ b/_posts/30-09-01-PaaS-Providers.md
@@ -12,3 +12,4 @@ isChild: true
 * [Nodester](http://nodester.com) - Node.JS
 * [OpenShift](https://openshift.redhat.com) - Node.JS
 * [JSApp.US](http://jsapp.us/)
+* [Windows Azure](http://www.windowsazure.com/en-us/develop/nodejs/)


### PR DESCRIPTION
The link is directly to the Node.js-specific landing page withing the Windows Azure site.
