### PR TITLE
Fix typo’d URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Note
 
 As you might have seen, the code in this repository makes reference to the old website. The new one, is still only html, and I need help to port it to Docpad or some other tool to make it easy for other people to contribute. 
-So, if you have knowledge to make it happen, please fork this project and checkout the `latest` branch. There you'll see the website on [JSTRW](http://jstherightway.com). Feel free to contact me if you need anything `sudowilliam@gmail.com`.
+So, if you have knowledge to make it happen, please fork this project and checkout the `latest` branch. There you'll see the website on [JSTRW](http://jstherightway.org). Feel free to contact me if you need anything `sudowilliam@gmail.com`.
 
 Thanks, and let's continue to improve this guide and provide the best resources to the JavaScript community!
 


### PR DESCRIPTION
I’m guessing this was meant to be the `.org` domain and not [this](http://jstherightway.com):

![2014-01-21 at 2 57 pm](https://f.cloud.github.com/assets/296432/1964362/5b0bd64a-82ac-11e3-8505-ba46841eff17.png)

Note that this is the case [on `master`](https://github.com/braziljs/js-the-right-way/blob/master/README.md#note) too, so it might need to be ported back or something so people landing on the repo’s main page don’t click on it too.
