### PR TITLE
TJ's user badge not centralized

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -326,7 +326,7 @@ header small {
 }
 
 .user {
-    width: 80px;
+    width: 120px;
     height: 160px;
     display: inline-block;
     margin: 0 50px;


### PR DESCRIPTION
Hi BrazilJS folks!

When I was searching for some info in the JS The Right Way website, pretty great site btw, I noticed that TJ Holowaychuck's name was not properly centralized as you can see in the screenshot or by comparing with my fork.

Before:
![f1](https://f.cloud.github.com/assets/1051644/1986605/22ac1ef6-844e-11e3-89c0-f060fd835769.jpg)

After:
![f2](https://f.cloud.github.com/assets/1051644/1986606/26abbb24-844e-11e3-90e3-d2862b0f8f87.jpg)

To fix this I propose that we increase the user class width to 120px instead for 80px, this way the name fits properly like the others.

As you can see this is just a small fix, so I didn't felt the need to open an issue thus I'm sending this PR right away.
