### PR TITLE
Adding link to http://w3fools.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,6 +746,9 @@
 
                 <section class="links-container">
                     <p class="source link">
+                        <a href="http://www.w3fools.com" target="_blank">W3Fools</a>
+                    </p>
+                    <p class="source link">
                         <a href="http://developer.mozilla.org/docs/JavaScript" target="_blank">Mozilla Developer Network</a>
                     </p>
                     <p class="source link">


### PR DESCRIPTION
I guess it would be nice to have it in the links section, so people would be aware of the w3schools problem as soon as possible.
