### PR TITLE
fix 18 errors of w3c validator, target blank in fork github link, scale in images helper

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -276,6 +276,11 @@ header small {
 
 #helpers a:hover img {
     opacity: 1;
+    -webkit-transform: scale(1.4);
+    -moz-transform: scale(1.4);
+    -ms-transform: scale(1.4);
+    -o-transform: scale(1.4);
+    transform: scale(1.4);
 }
 
 #helpers a img {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
     <body>
         <header>
-            <a class="fork-me" href="https://github.com/braziljs/js-the-right-way"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
+            <a class="fork-me" href="https://github.com/braziljs/js-the-right-way" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub" /></a>
 
             <section class="wrapper">
                 <h1>JavaScript</h1>
@@ -31,13 +31,13 @@
         <section class="social">
             <section class="github">
                 <section class="wrapper">
-                    <iframe class="gh-button" src="http://ghbtns.com/github-btn.html?user=braziljs&repo=js-the-right-way&type=watch&count=true"
+                    <iframe class="gh-button" src="http://ghbtns.com/github-btn.html?user=braziljs&amp;repo=js-the-right-way&amp;type=watch&amp;count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
 
-                    <iframe class="gh-button" src="http://ghbtns.com/github-btn.html?user=braziljs&repo=js-the-right-way&type=fork&count=true"
+                    <iframe class="gh-button" src="http://ghbtns.com/github-btn.html?user=braziljs&amp;repo=js-the-right-way&amp;type=fork&amp;count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
 
-                    <iframe class="gh-follow-button" src="http://ghbtns.com/github-btn.html?user=gnuwilliam&type=follow&count=true"
+                    <iframe class="gh-follow-button" src="http://ghbtns.com/github-btn.html?user=gnuwilliam&amp;type=follow&amp;count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="165" height="20"></iframe>
                 </section>
             </section>
@@ -568,7 +568,7 @@
 
             </section>
         </section>
-
+        
         <section class="section" id="reading">
             <section class="wrapper">
                 <h1>Reading</h1>
@@ -855,27 +855,27 @@
 
                 <div class="helpers-container">
                     <a target="_blank" href="https://npmjs.org/">
-                        <img src="assets/npm.png">
+                        <img src="assets/npm.png" alt="npm" />
                     </a>
 
                     <a target="_blank" href="http://bower.io/">
-                        <img src="assets/bower-logo.png">
+                        <img src="assets/bower-logo.png" alt="bower" />
                     </a>
 
                     <a target="_blank" href="http://yeoman.io/">
-                        <img src="assets/yeoman-logo.png">
+                        <img src="assets/yeoman-logo.png" alt="yeoman" />
                     </a>
 
                     <a target="_blank" href="http://gruntjs.com/">
-                        <img src="assets/grunt-logo.png">
+                        <img src="assets/grunt-logo.png" alt="grunt" />
                     </a>
 
                     <a target="_blank" href="http://gulpjs.com/">
-                        <img src="assets/gulp.png">
+                        <img src="assets/gulp.png" alt="gulp" />
                     </a>
 
                     <a target="_blank" href="http://todomvc.com/">
-                        <img src="assets/todomvc-logo.png">
+                        <img src="assets/todomvc-logo.png" alt="todo mvc" />
                     </a>
                 </div>
             </div>
@@ -887,7 +887,7 @@
 
                 <div class="screencasts-container">
                     <a href="https://egghead.io/" target="_blank">
-                        <img src="assets/egghead.svg">
+                        <img src="assets/egghead.svg" alt="egghead" />
                     </a>
                 </div>
             </div>
@@ -898,7 +898,7 @@
                 <div class="bio">
                     <h3>Created and maintained by</h3>
                     <a class="william" href="https://github.com/gnuwilliam">
-                        <img src="https://0.gravatar.com/avatar/05671f27a334fd17b787a88bf3d7d5b8?d=https%3A%2F%2Fidenticons.github.com%2Fdf5529fee499f928d4cfe6ffdac9d89c.png&r=x&s=440">
+                        <img src="https://0.gravatar.com/avatar/05671f27a334fd17b787a88bf3d7d5b8?d=https%3A%2F%2Fidenticons.github.com%2Fdf5529fee499f928d4cfe6ffdac9d89c.png&amp;r=x&amp;s=440" alt="William oliveira" />
                         <b>William Oliveira</b>
                     </a>
 


### PR DESCRIPTION
- Fix 18 errors of w3c validator
  I checked http://jstherightway.org/ in http://validator.w3.org/ and was found 30 errors and 4 warnings. I fixed 18 errors. Only I don't fixed all errors, because the code have many iframes and attributes that are bad for w3c validator.
- target blank
  lacked a target _blank in fork link.
- scale in images helper
  In the images of helper section I did a scale transform.
