### PR TITLE
Update TJ's username

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -9,7 +9,7 @@ var users = [
   'joezimjs', 
   'douglascrockford',
   'paulirish',
-  'visionmedia',
+  'tj',
   'guille',
   'nzakas',
   'jeresig',


### PR DESCRIPTION
TJ Holowaychuk's username is [tj](https://github.com/tj) now, not visionmedia anymore.
