### PR TITLE
ES2016 specification

### DIFF
--- a/i18n/en-us/partials/getting-started.html
+++ b/i18n/en-us/partials/getting-started.html
@@ -13,7 +13,7 @@
 <h3>CURRENT VERSION</h3>
 
 <p>
-    The JavaScript standard is ECMAScript. As of 2012, all modern browsers fully support ECMAScript 5.1. Older browsers support at least ECMAScript 3. As of June 2015 the spec for ES6/ES2015 has been approved. See the ECMAScript 2015 Language Specification at <a target="_blank" href="http://www.ecma-international.org/ecma-262/6.0/index.html">Ecma International</a>.
+    The JavaScript standard is ECMAScript. As of 2012, all modern browsers fully support ECMAScript 5.1. Older browsers support at least ECMAScript 3. As of June 2015 the spec for ES6/ES2015 has been approved. Following the new annual release cycle, ES7/ES2016 has been adopted in June 2016. See the ECMAScript 2016 Language Specification at <a target="_blank" href="http://www.ecma-international.org/ecma-262/7.0/index.html">Ecma International</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Add sentence mentioning the new ES2016 spec.
Update link to match the current ES2016 standard.