### PR TITLE
fixed link to Google JS Style Guide

### DIFF
--- a/public/en-us/index.html
+++ b/public/en-us/index.html
@@ -144,7 +144,7 @@
                 <h3>Conventions</h3>
 
 <p>
-    As every language, JavaScript has many code style guides. Maybe the most used and recommended is the <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Google Code Style Guide for JavaScript</a>, but we recommend you read <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>.
+    As every language, JavaScript has many code style guides. Maybe the most used and recommended is the <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Google Code Style Guide for JavaScript</a>, but we recommend you read <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>.
 </p>
 
 <h3>Linting</h3>


### PR DESCRIPTION
(now on GitHub)