### PR TITLE
Remove DailyJS Alex Young killed it

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -819,9 +819,6 @@ It is an important concept to understand as it can be useful during development,
                         <a href="http://javascript.com" target="_blank">JavaScript.com</a>
                     </p>
                     <p class="source link">
-                        <a href="http://dailyjs.com" target="_blank">DailyJS</a>
-                    </p>
-                    <p class="source link">
                         <a href="http://www.echojs.com" target="_blank">Echo JS</a>
                     </p>
                     <p class="source link">


### PR DESCRIPTION
As posted by Alex on July 7th, 2015, the [DailyJS](http://dailyjs.com/) blog has come to an end. It should therefore be removed from the News Websites section.
