### PR TITLE
Update the link of Google JavaScript Style Guide

### DIFF
--- a/i18n/de-de/partials/code-style.html
+++ b/i18n/de-de/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>Richtlinien</h3>
 
 <p>
-    Auch JavaScript hat, so wie jede Programmiersprache, viele unterschiedliche Leitfäden für den Code-Style. Der womöglich am meisten verwendete und weiterempfohlene ist der <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Google Code-Style-Guide für JavaScript</a>, aber wir empfehlen dir <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a> zu lesen.
+    Auch JavaScript hat, so wie jede Programmiersprache, viele unterschiedliche Leitfäden für den Code-Style. Der womöglich am meisten verwendete und weiterempfohlene ist der <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Google Code-Style-Guide für JavaScript</a>, aber wir empfehlen dir <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a> zu lesen.
 </p>
 
 <h3>Code-Analyse (Linting)</h3>

--- a/i18n/es-es/partials/code-style.html
+++ b/i18n/es-es/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>Convenciones</h3>
 
 <p>
-    Como todo lenguaje, JavaScript tiene muchas guías de estilo. Quizas la más usada y recomendada es la <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Guía de Estilo de Google para JavaScript</a>, pero nosotros te recomendamos leer <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>.
+    Como todo lenguaje, JavaScript tiene muchas guías de estilo. Quizas la más usada y recomendada es la <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Guía de Estilo de Google para JavaScript</a>, pero nosotros te recomendamos leer <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>.
 </p>
 
 <h3>Linting</h3>

--- a/i18n/fa-ir/partials/code-style.html
+++ b/i18n/fa-ir/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>Conventions</h3>
 
 <p>
-    As every language, JavaScript has many code style guides. Maybe the most used and recommended is the <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Google Code Style Guide for JavaScript</a>, but we recommend you read <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>.
+    As every language, JavaScript has many code style guides. Maybe the most used and recommended is the <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Google Code Style Guide for JavaScript</a>, but we recommend you read <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>.
 </p>
 
 <h3>Linting</h3>

--- a/i18n/ko-kr/partials/code-style.html
+++ b/i18n/ko-kr/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>컨벤션 (코드 작성 규칙)</h3>
 
 <p>
-    다른 언어들과 마찬가지로 JavaScript에도 다양한 코딩 스타일 규칙이 있습니다. 아마도 가장 많은 이들이 사용하고, 추천하는 것은 <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">구글 JavaScript 코드 스타일 규칙</a>일 것입니다. 하지만 우리는 당신에게 <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a> 를 읽어볼 것을 추천합니다.
+    다른 언어들과 마찬가지로 JavaScript에도 다양한 코딩 스타일 규칙이 있습니다. 아마도 가장 많은 이들이 사용하고, 추천하는 것은 <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">구글 JavaScript 코드 스타일 규칙</a>일 것입니다. 하지만 우리는 당신에게 <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a> 를 읽어볼 것을 추천합니다.
 </p>
 
 <h3>린팅 (코드 스타일 검사)</h3>

--- a/i18n/pt-br/partials/code-style.html
+++ b/i18n/pt-br/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>Convenções</h3>
 
 <p>
-    Assim como todas as linguagens, JavaScript tem muitos guias de estilo de código. Talvez o mais usado e recomendado seja o <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Google Code Style Guide for JavaScript</a>, mas recomendamos a leitura do <a target="_blank" href="https://github.com/rwaldron/idiomatic.js/tree/master/translations/pt_BR">Idiomatic.js</a>.
+    Assim como todas as linguagens, JavaScript tem muitos guias de estilo de código. Talvez o mais usado e recomendado seja o <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Google Code Style Guide for JavaScript</a>, mas recomendamos a leitura do <a target="_blank" href="https://github.com/rwaldron/idiomatic.js/tree/master/translations/pt_BR">Idiomatic.js</a>.
 </p>
 
 <h3>Análise de código (<i>Linting</i>)</h3>

--- a/i18n/zh-cn/partials/code-style.html
+++ b/i18n/zh-cn/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>编程风格规范</h3>
 
 <p>
-    JavaScript 和其他编程语言一样，有各种版本的编程风格指南。或许大家会推荐 <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Google Code Style Guide for JavaScript</a>，但我们更推荐 <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>
+    JavaScript 和其他编程语言一样，有各种版本的编程风格指南。或许大家会推荐 <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Google Code Style Guide for JavaScript</a>，但我们更推荐 <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>
 </p>
 
 <h3>代码检查</h3>

--- a/i18n/zh-tw/partials/code-style.html
+++ b/i18n/zh-tw/partials/code-style.html
@@ -1,7 +1,7 @@
 <h3>程式碼慣例</h3>
 
 <p>
-    JavaScript 和其他程式語言一樣，有各種版本的編碼風格指引。或許大家常會推薦 <a target="_blank" href="http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml">Google Code Style Guide for JavaScript</a>，但我們更推薦 <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>
+    JavaScript 和其他程式語言一樣，有各種版本的編碼風格指引。或許大家常會推薦 <a target="_blank" href="https://google.github.io/styleguide/javascriptguide.xml">Google Code Style Guide for JavaScript</a>，但我們更推薦 <a target="_blank" href="https://github.com/rwldrn/idiomatic.js/">Idiomatic.js</a>
 </p>
 
 <h3>程式碼檢查</h3>


### PR DESCRIPTION
In the `CODE STYLE` section, the [link](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml) of Google Style Guide is dead, let's use the [new one](https://google.github.io/styleguide/javascriptguide.xml)

