### PR TITLE
Updated the old loose typing link that 404s

### DIFF
--- a/public/de-de/index.html
+++ b/public/de-de/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    Quelle: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    Quelle: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>Scoping und Hoisting</h3>

--- a/public/en-us/index.html
+++ b/public/en-us/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    Source: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    Source: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>Scoping and Hoisting</h3>

--- a/public/es-es/index.html
+++ b/public/es-es/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    Fuente: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    Fuente: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>Scoping and Hoisting (Alcance y Elevación)</h3>

--- a/public/fa-ir/index.html
+++ b/public/fa-ir/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    Source: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    Source: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>Scoping and Hoisting</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    Source: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    Source: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>Scoping and Hoisting</h3>

--- a/public/ko-kr/index.html
+++ b/public/ko-kr/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    참고: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    참고: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>스코핑과 호이스팅</h3>

--- a/public/pt-br/index.html
+++ b/public/pt-br/index.html
@@ -224,7 +224,7 @@
 </p>
 
 <p class="source">
-    Fonte: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    Fonte: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>Escopos e elevação (<i>hoisting</i>)</h3>

--- a/public/ru-ru/index.html
+++ b/public/ru-ru/index.html
@@ -224,7 +224,7 @@
 </p>
 
 <p class="source">
-    Подробнее: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Понимание нестрогой типизации в JavaScript</a>
+    Подробнее: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Понимание нестрогой типизации в JavaScript</a>
 </p>
 
 <h3>Область видимости и всплытие определений</h3>

--- a/public/zh-cn/index.html
+++ b/public/zh-cn/index.html
@@ -217,7 +217,7 @@
 </p>
 
 <p class="source">
-    资源: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    资源: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>作用域和提升</h3>

--- a/public/zh-tw/index.html
+++ b/public/zh-tw/index.html
@@ -223,7 +223,7 @@
 </p>
 
 <p class="source">
-    來源: <a target="_blank" href="http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html">Understanding Loose Typing in JavaScript</a>
+    來源: <a target="_blank" href="https://accreditly.io/articles/understanding-loose-typing-in-javascript">Understanding Loose Typing in JavaScript</a>
 </p>
 
 <h3>作用域及變數提升</h3>


### PR DESCRIPTION
Old link: http://blog.jeremymartin.name/2008/03/understanding-loose-typing-in.html

This link is now dead, but for the longest time was also running on http (no SSL/HTTPS). I can't tell what the site is now doing, but looks like the domain expired and was repurchased by someone else in 2023.

This PR replaces the link with another article, covering the same topic in more detail. Change has been made across all languages.

New link: https://accreditly.io/articles/understanding-loose-typing-in-javascript

Thanks